### PR TITLE
Update version file for latest release

### DIFF
--- a/PlanetShine/Distribution/GameData/PlanetShine/Plugins/PlanetShine.version
+++ b/PlanetShine/Distribution/GameData/PlanetShine/Plugins/PlanetShine.version
@@ -1,36 +1,33 @@
 {
-    "NAME":"PlanetShine",
-    "URL":"https://github.com/PapaJoesSoup/ksp-planetshine/blob/master/PlanetShine/Distribution/GameData/PlanetShine/Plugins/PlanetShine.version",
-    "DOWNLOAD":"https://github.com/PapaJoesSoup/ksp-planetshine/releases",
+    "NAME": "PlanetShine",
+    "URL": "https://github.com/prestja/ksp-planetshine/raw/master/PlanetShine/Distribution/GameData/PlanetShine/Plugins/PlanetShine.version",
+    "DOWNLOAD": "https://github.com/prestja/ksp-planetshine/releases",
     "GITHUB":
     {
-        "USERNAME":"PapaJoesSoup",
-        "REPOSITORY":"ksp-planetshine",
-        "ALLOW_PRE_RELEASE":false
+        "USERNAME": "prestja",
+        "REPOSITORY": "ksp-planetshine",
+        "ALLOW_PRE_RELEASE": false
     },
     "VERSION":
     {
-        "MAJOR":0,
-        "MINOR":2,
-        "PATCH":6,
-        "BUILD":1
+        "MAJOR": 0,
+        "MINOR": 2,
+        "PATCH": 6,
+        "BUILD": 2
     },
     "KSP_VERSION":
     {
-        "MAJOR":1,
-        "MINOR":4,
-        "PATCH":1
+        "MAJOR": 1,
+        "MINOR": 8
     },
     "KSP_VERSION_MIN":
     {
-        "MAJOR":1,
-        "MINOR":4,
-        "PATCH":0
+        "MAJOR": 1,
+        "MINOR": 8
     },
     "KSP_VERSION_MAX":
     {
-        "MAJOR":1,
-        "MINOR":4,
-        "PATCH":999
+        "MAJOR": 1,
+        "MINOR": 8
     }
 } 


### PR DESCRIPTION
KSP-CKAN/NetKAN#7523 is requesting that CKAN's entry for PlanetShine be switched to this branch. We like to take a look at mods before doing that to make sure the switchover will go smoothly.

Currently that PR is replacing the `$vref` property with a hard coded game version. This isn't a good idea.

This PR updates the version file so the `$vref` can be kept. Note that a new release or a replacement of the current release would be needed for that to take effect.